### PR TITLE
Uses 1st microcluster voter to handle mirror

### DIFF
--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -3,6 +3,7 @@ import time
 
 import jubilant
 import pytest
+import json
 
 microovn_charm_path = "./" + os.environ.get("MICROOVN_CHARM_PATH")
 if microovn_charm_path is None:
@@ -28,11 +29,6 @@ def juju():
                 continue
             raise e
 
-def test_deploy(juju: jubilant.Juju):
-    juju.deploy(microovn_charm_path)
-    juju.wait(jubilant.all_active)
-    juju.exec("microovn status", unit="microovn/0")
-    
 def test_integrate(juju: jubilant.Juju):
     juju.deploy(microovn_charm_path)
     juju.add_unit("microovn")
@@ -44,7 +40,8 @@ def test_integrate(juju: jubilant.Juju):
 def test_integrate_post_start(juju: jubilant.Juju):
     juju.deploy(microovn_charm_path)
     juju.deploy(token_distributor_charm_path)
-    juju.wait(jubilant.all_active)
+    juju.wait(lambda status: jubilant.all_active(status, "microcluster-token-distributor"))
+    juju.wait(lambda status: jubilant.all_maintenance(status, "microovn"))
     juju.integrate("microovn","microcluster-token-distributor")
     juju.add_unit("microovn")
     juju.wait(jubilant.all_active)
@@ -61,3 +58,22 @@ def test_token_distributor_down(juju: jubilant.Juju):
     juju.add_unit("microovn")
     juju.wait(jubilant.all_active)
     juju.exec("microovn status", unit="microovn/2")
+
+def test_microcluster_leader_down(juju: jubilant.Juju):
+    juju.deploy(microovn_charm_path)
+    juju.add_unit("microovn")
+    juju.deploy(token_distributor_charm_path)
+    juju.integrate("microovn","microcluster-token-distributor")
+    juju.wait(jubilant.all_active)
+    output = juju.exec("microovn cluster list -f json", unit="microovn/0").stdout
+    json_output = json.loads(output)
+    voter_names = [ x["name"] for x in json_output
+                    if (x["role"] in ["voter", "PENDING"]) and (x["status"] == "ONLINE") ]
+    voter_name = min(voter_names)
+    hostname = juju.exec("hostname -s",unit="microovn/0").stdout[:-1]
+    if hostname == voter_name:
+        juju.remove_unit("microovn/0")
+    else:
+        juju.remove_unit("microovn/1")
+    juju.add_unit("microovn")
+    juju.wait(jubilant.all_active)


### PR DESCRIPTION
Instead of using the leader to communicate with the token distributor, we now generate a list of online microcluster voters and then take the 1st unit when listed alphabetically.

This greatly improves cluster reliability