### PR TITLE
Update cryptography dependency

### DIFF
--- a/microovn/requirements.txt
+++ b/microovn/requirements.txt
@@ -1,3 +1,3 @@
 ops ~= 2.17
-cryptography==43.0.1
+cryptography==44.0.1
 pydantic==2.9.1

--- a/tests/interface-consumer/requirements.txt
+++ b/tests/interface-consumer/requirements.txt
@@ -1,3 +1,3 @@
 ops ~= 2.17
-cryptography==43.0.1
+cryptography==44.0.1
 pydantic==2.9.1


### PR DESCRIPTION
both microovn-operator and interface-consumer are on 43.0.1 when they should be on 44.0.1