### PR TITLE
test: verify central IPs are set even when central is already disabled

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -641,7 +641,13 @@ def test_dataplane_mode_disable_central_fails_already_disabled(
         manager.charm.token_consumer._stored.in_cluster = True
         result = manager.charm._dataplane_mode()
 
+    # Previously the early return skipped this call, verify it now runs
+    # even when central was already disabled.
     assert result is True
+    mock_call_microovn_command.assert_any_call(
+        "disable", "central", "--allow-disable-last-central"
+    )
+    mock_call_microovn_command.assert_any_call("config", "set", "ovn.central-ips", "192.168.0.16")
 
 
 def test_dataplane_mode_disable_central_fails_other_error(


### PR DESCRIPTION
Add assert_any_call checks for both the 'disable central' and 'config set ovn.central-ips' calls in
test_dataplane_mode_disable_central_fails_already_disabled.

The test previously only asserted the return value, leaving the regression fixed in 31ff7e25 uncovered.
The new assertions ensure both commands are always called in this path.