### PR TITLE
Changes to get microovn working for PS9

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -265,7 +265,19 @@ class MicroovnCharm(ops.CharmBase):
         subprocess.run(["systemctl", "disable", "--now", APT_OVS_SERVICE])
         subprocess.run(["modprobe", "-r", "openvswitch"])
         subprocess.run(["modprobe", "openvswitch"])
-        subprocess.run(["apt", "remove", "-y", *APT_OVS_PACKAGES])
+
+        # Some services such as netplan check for ovs-vsctl in usr/bin before
+        # snap/bin to work out which to use, we want it using ovs-vsctl provided
+        # by microovn but we cannot remove certain packages such as ovs-doca. So
+        # we must just remove the binary. This will cause maintenance headaches
+        # and is a bad solution but we do not have a better one.
+        #
+        # I hope this code is not here for long. (17/04/26)
+        subprocess.run(["rm", "-f", "/usr/bin/ovs-vsctl"])
+
+        # Removes existing OVS as two versions of openvswitch running at once
+        # causes many issues we would like to avoid.
+        subprocess.run(["apt", "remove", "-y", "--allow-change-held-packages", *APT_OVS_PACKAGES])
 
     def _on_prebootstrap_or_prejoin(self, event: ops.EventBase) -> None:
         """Handle the pre join/pre bootstrap hook."""

--- a/src/constants.py
+++ b/src/constants.py
@@ -23,7 +23,7 @@ APT_OVS_SERVICE = "openvswitch-switch.service"
 MICROOVN_SNAP_COMMON = "/var/snap/microovn/common"
 MICROOVN_OVSDB_DIR = f"{MICROOVN_SNAP_COMMON}/data/switch/db"
 MICROOVN_OVS_CONF_DB = f"{MICROOVN_OVSDB_DIR}/conf.db"
-APT_OVS_PACKAGES = ["openvswitch-switch", "python3-openvswitch", "doca-openvswitch-switch"]
+APT_OVS_PACKAGES = ["openvswitch-switch", "python3-openvswitch"]
 
 OVN_EXPORTER_PLUGS: List[Tuple[str, str | None]] = [
     ("ovn-chassis", "microovn:ovn-chassis"),


### PR DESCRIPTION
we cannot remove doca-openvswitch-switch as it is depended on, so we remove ovs-vsctl.
openvswitch-switch is marked as held by maas so we need to force remove it.