### PR TITLE
Use vendored rust compiler.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,11 +29,12 @@ parts:
   rust-deps:
     plugin: nil
     build-packages:
-      - rustup
+      - cargo-1.91
+      - rustc-1.91
     override-build: |
+      ln -s /usr/bin/rustc-1.91 /usr/bin/rustc
+      ln -s /usr/bin/cargo-1.91 /usr/bin/cargo
       craftctl default
-      rustup set profile minimal
-      rustup default 1.92.0
       cargo --version
   poetry-deps:
     plugin: nil


### PR DESCRIPTION
The commit in the fixes tag addressed a situation in the Python dependency sphere by updating the rust compiler through rustup.

Since then Rust 1.91 has been made available for the Ubuntu 24.04 build base, and we prefer a vendored version of the compiler for security and stability reasons.

Fixes: 1993b7465e14 ("feat: add role-assignment requirer integration")
Reported-at: https://launchpad.net/bugs/2148642

A successful build across all architectures can be viewed here: https://launchpad.net/~fnordahl/fnordahl-craft-remote-build/+charm/charmcraft-microovn-2bdaed61d392c47c5827005fb3278b59