### PR TITLE
Handle snapd latest/edge when on the latest charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -42,6 +42,7 @@ from constants import (
     OVSDB_RELATION,
     OVSDBCMD_RELATION,
     ROLE_ASSIGNMENT_RELATION,
+    SNAPD_CHANNEL,
     WORKER_RELATION,
 )
 from role_handler import RoleHandler
@@ -150,6 +151,11 @@ class MicroovnCharm(ops.CharmBase):
     def ovn_exporter_snap_client(self) -> SnapManager:  # pragma: nocover
         """Return the snap client."""
         return SnapManager("ovn-exporter", self.ovn_exporter_snap_channel)
+
+    @cached_property
+    def snapd_snap_client(self) -> SnapManager:  # pragma: nocover
+        """Return the snap client."""
+        return SnapManager("snapd", SNAPD_CHANNEL)
 
     @property
     def is_in_cluster(self) -> bool:
@@ -337,6 +343,11 @@ class MicroovnCharm(ops.CharmBase):
         # Open vSwitch instance.
         subprocess.run(["mkdir", "-p", MICROOVN_SNAP_COMMON])
         subprocess.run(["touch", MICROOVN_SNAP_COMMON + "/break_system_ovs"])
+
+        self.unit.status = ops.MaintenanceStatus(f"Installing {self.snapd_snap_client.name} snap")
+        if not self.snapd_snap_client.install():
+            logger.error("Failed to install %s snap", self.snapd_snap_client.name)
+            raise RuntimeError(f"Failed to install {self.snapd_snap_client.name} snap")
 
         snaps = [self.ovn_exporter_snap_client, self.microovn_snap_client]
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -13,6 +13,7 @@ CERTIFICATES_RELATION = "certificates"
 OVSDBCMD_RELATION = "ovsdb-external"
 ROLE_ASSIGNMENT_RELATION = "role-assignment"
 MICROOVN_TRACK = "latest"
+SNAPD_CHANNEL = "latest/edge"
 VALID_SNAP_RISKS = ["stable", "candidate", "beta", "edge"]
 DASHBOARDS_DIR = "./src/dashboards"
 ALERT_RULES_DIR = "./src/prometheus_alert_rules"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,6 +66,15 @@ def mock_ovn_exporter_snap():
 
 
 @pytest.fixture()
+def mock_snapd_snap():
+    """Mock the microovn snap client for charm tests."""
+    mock_snap = MagicMock(spec=SnapManager)
+    mock_snap.name = "snapd"
+    with patch.object(MicroovnCharm, "snapd_snap_client", mock_snap):
+        yield mock_snap
+
+
+@pytest.fixture()
 def mock_check_metrics_endpoint():
     """Mock check_metrics_endpoint function."""
     with patch("charm.check_metrics_endpoint") as mock:
@@ -134,6 +143,7 @@ def test_on_install_success(
     mock_subprocess_run,
     mock_microovn_snap,
     mock_ovn_exporter_snap,
+    mock_snapd_snap,
     mock_check_metrics_endpoint,
     mock_wait_for_microovn_ready,
 ):
@@ -143,6 +153,7 @@ def test_on_install_success(
 
     mock_ovn_exporter_snap.install.assert_called_once()
     mock_microovn_snap.install.assert_called_once()
+    mock_snapd_snap.install.assert_called_once()
     mock_ovn_exporter_snap.connect.assert_called_once_with(
         [
             ("ovn-chassis", "microovn:ovn-chassis"),
@@ -164,6 +175,7 @@ def test_on_install_snap_fails(
     mock_subprocess_run,
     mock_microovn_snap,
     mock_ovn_exporter_snap,
+    mock_snapd_snap,
     mock_check_metrics_endpoint,
     mock_wait_for_microovn_ready,
     failing_snap,
@@ -184,6 +196,7 @@ def test_on_install_connect_fails(
     mock_subprocess_run,
     mock_microovn_snap,
     mock_ovn_exporter_snap,
+    mock_snapd_snap,
     mock_check_metrics_endpoint,
     mock_wait_for_microovn_ready,
 ):
@@ -201,6 +214,7 @@ def test_on_install_waitready_fails(
     mock_subprocess_run,
     mock_microovn_snap,
     mock_ovn_exporter_snap,
+    mock_snapd_snap,
     mock_check_metrics_endpoint,
     mock_wait_for_microovn_ready,
 ):


### PR DESCRIPTION
This should not be backported but in latest we do sometimes need to use snapd features from latest/edge, sometimes not using these even blocks core26