### PR TITLE
Rework our release process documentation.

### DIFF
--- a/RELEASE_PROCESS.org
+++ b/RELEASE_PROCESS.org
@@ -9,7 +9,7 @@ expected ubuntu image.
 Stable MicroOVN charm releases follow the [[https://ubuntu.com/about/release-cycle][Ubuntu release cycle]], and a new
 stable version is made shortly after each new Ubuntu LTS release.
 
-The [[**Stable-Branches][Stable branches]] are named "branch-YY.MM", where the numbers come from
+The [[*Stable Branches][Stable branches]] are named "branch-YY.MM", where the numbers come from
 the corresponding MicroOVN snap version string, for example: "branch-25.03".
 
 ** Stable Branches
@@ -17,11 +17,47 @@ We go out of our way to embed logic in the product itself, its test suite
 and CI pipeline to avoid manual effort on each new release.
 
 Steps to cut a stable branch:
-1. Create a branch "branch-YY.MM" at the commit agreed for version cutoff.
-2. Create a commit "Prepare for YY.MM", This should:
-   - Set the charmcraft base to ~ubuntu@YY.04~
-   - Update MICROOVN_TRACK in [[file:src/constants.py][src/constants.py]] to "YY.MM"
-   - Update the default risk in [[file:charmcraft.yaml][charmcraft.yaml]] to "stable"
-3. Create a PR named "YY.MM Release" for the branch "branch-YY.MM" containing
-    this commit.
-4. Review and merge.
+*** Create a branch "prepare-YY.MM" at the commit agreed for version cutoff
+#+begin_src shell :session release :results output :exports both
+git checkout main
+VERSION=$(date +%y.03)
+git switch -C prepare-$VERSION
+#+end_src
+
+*** Create a commit "prepare for YY.MM", this should:
+- set the charmcraft platforms to the latest stable release
+- update microovn_track in [[file:src/constants.py][src/constants.py]] to "yy.mm"
+- update the default risk in [[file:charmcraft.yaml][charmcraft.yaml]] to "stable"
+#+begin_src shell :session release :results output :exports both
+lts=$(($(date +%y) /2 *2)).04
+sed -i -E "s/ubuntu@[0-9]{2}\.04/ubuntu@$lts/g" charmcraft.yaml
+sed -i -E "s/(MICROOVN_TRACK) = .*/\1 = \"$VERSION\"/" src/constants.py
+sed -i '
+  /microovn_risk:/{
+  N
+  s/\(default: \).*/\1stable/
+  }
+' charmcraft.yaml
+
+git add charmcraft.yaml src/constants.py
+git commit -m "prepare for $VERSION" --signoff
+#+end_src
+
+*** Create a commit "return to latest/edge" this should:
+- update microovn_track in [[file:src/constants.py][src/constants.py]] to "latest"
+- update the default risk in [[file:charmcraft.yaml][charmcraft.yaml]] to "edge"
+#+begin_src shell :session release :results output :exports both
+sed -i -E "s/(MICROOVN_TRACK) = .*/\1 = \"latest\"/" src/constants.py
+sed -i '
+  /microovn_risk:/{
+  N
+  s/\(default: \).*/\1edge/
+  }
+' charmcraft.yaml
+
+git add charmcraft.yaml src/constants.py
+git commit -m "return to latest/edge" --signoff
+#+end_src
+
+*** Create a PR named "YY.MM Release" merging prepare-YY.MM into main
+*** Once Merged, create branch-YY.MM from the "prepare for YY.MM" commit

--- a/org-accessibility/org-runner.py
+++ b/org-accessibility/org-runner.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Script to run org source blocks outside of emacs."""
+import json
+import re
+import subprocess
+import sys
+import tempfile
+
+SRC_BLOCK_RE = re.compile(
+    r"#\+BEGIN_SRC\s+(python|sh|shell)[^\n]*\n(.*?)\n#\+END_SRC",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+class Block:
+    """Simple class to store data for a block."""
+    def __init__(self, heading, depth):
+        self.content = {"text": ""}
+        self.depth = depth
+        self.children = []
+        self.heading = heading
+
+class IvyEncoder(json.JSONEncoder):
+    """Encoder class for JSON output."""
+    def default(self, o):
+        """Convert a block to a dictionary readable format for JSON."""
+        if isinstance(o,Block):
+            return {
+                "content": o.content,
+                "depth":o.depth,
+                "heading":o.heading,
+                "children":[self.default(c) for c in o.children]
+            }
+        else:
+            pass
+
+
+def run_python(code: str):
+    """Run python source block."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+        result = subprocess.run(
+            ["python3", f.name],
+            capture_output=True,
+            text=True,
+        )
+    return result.stdout, result.stderr
+
+def run_shell(code: str):
+    """Run python source shell."""
+    result = subprocess.run(
+        ["sh", "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout, result.stderr
+
+def execute_block(lang: str, code: str):
+    """Run a code block with the proper interpreter."""
+    lang = lang.lower()
+
+    if lang == "python":
+        return run_python(code)
+    elif lang in ("sh", "shell"):
+        return run_shell(code)
+    else:
+        return "", f"Unsupported language: {lang}\n"
+
+def build_org_tree(f):
+    """Convert a file to a Block tree."""
+    tree = Block("",0)
+    stack = [tree]
+    part = "content"
+    for line in f:
+        stars = 0
+        while line[stars] == "*":
+            stars+=1
+        if stars > 0:
+            heading = line[stars+1:][:-1]
+
+            new_node = Block(heading,stars)
+            if stars > stack[-1].depth:
+                stack[-1].children.append(new_node)
+                stack.append(new_node)
+                part="text"
+            else:
+                while stack[-1].depth>=stars:
+                    stack.pop()
+                stack[-1].children.append(new_node)
+                stack.append(new_node)
+                part="text"
+        else:
+            if "#+begin_src" in line.lower():
+                src_parts = line.split(" ")
+                part = src_parts[1]
+                if not stack[-1].content.get(part):
+                    stack[-1].content[src_parts[1]] = ""
+            elif "#+end_src" in line.lower():
+                part = "text"
+            else:
+                stack[-1].content[part] = stack[-1].content[part] + line
+    return tree
+
+def extract_code(block, children=True):
+    """Given a block, extract its code by language to a dict."""
+    d = {}
+    for x in block.content.keys():
+        if x != "text":
+            d[x] = block.content[x]
+    if children:
+        for child in block.children:
+            new_d = extract_code(child,True)
+            for k in new_d.keys():
+                if d.get(k):
+                    d[k]+="\n"+new_d[k]
+                else:
+                    d[k]=new_d[k]
+    return d
+
+
+
+def main(path,headings):
+    """Parse the file and run the internal code."""
+    with open(path) as f:
+        t = build_org_tree(f)
+
+
+    if len(headings)>0:
+        for heading in headings:
+            parts = heading.split(".")
+            block = t
+            for p in parts:
+                if lx := [x for x in block.children if x.heading ==p]:
+                    block = lx[0]
+                else:
+                    print("INVALID HEADING")
+            block_dict = extract_code(block)
+
+            for lang in block_dict.keys():
+                print(f"Running {lang} block:\n{block_dict[lang]}\n")
+                out, err = execute_block(lang, block_dict[lang])
+                if out:
+                    print("--- stdout ---")
+                    print(out.rstrip())
+
+                if err:
+                    print("--- stderr ---")
+                    print(err.rstrip())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: org_runner.py file.org [headings]*")
+        sys.exit(1)
+
+    main(sys.argv[1], sys.argv[2:])


### PR DESCRIPTION
This introduces example code blocks for our release documentation, which are easily runable with "RET" within org mode, or "m e O O" to export the whole file to a buffer containing the output of each block alongside the code.

For our less enlightened users, we now have the org-accessability directory, which I aim to expand with scripts giving core org-mode QoL features to those who dont use emacs. Currently this just contains the "org-runner.py" script, which extracts source blocks and then runs them with the relevant interpreter.

This should allow streamlined microovn-operator releases, alongside the ability for a non-emacs user to follow along with documentation such as README.org